### PR TITLE
新規投稿ページの作成と Firestore に投稿データの追加【 α版 】

### DIFF
--- a/pages/posts/new.vue
+++ b/pages/posts/new.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="new_post__container">
+    <div class="playback__container">
+      <video
+        :src="organismUrl"
+        width="240"
+        height="240"
+        controls
+      />
+    </div>
+    <div class="new_post">
+      <form>
+        <input
+          v-model="postData.title"
+          type="text"
+          value="Title"
+        >
+        <input
+          v-model="postData.place"
+          type="text"
+          value="Place"
+        >
+        <span>
+          What is the recording target?
+        </span>
+        <textarea
+          v-model="postData.target"
+          cols="20"
+          rows="5"
+        />
+        <span>
+          How are your feeling now?
+        </span>
+        <textarea
+          v-model="postData.feeling"
+          cols="20"
+          rows="5"
+        />
+      </form>
+      <div class="new_post__button__container">
+        <button>
+          CANCEL
+        </button>
+        <button @click="postSubmit()">
+          POST
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import { db } from '~/plugins/firebase'
+
+const postsCollection = db.collection('posts')
+
+export default {
+  data:() => ({
+    postData: {
+      title: '',
+      place: '',
+      target: '',
+      feeling: ''
+    }
+  }),
+  computed: {
+    ...mapState({
+      postId: store => store.post.postData.id,
+      organismUrl: store => store.post.postData.organismUrl
+    })
+  },
+  methods: {
+    postSubmit() {
+      const submitPostData = {
+        id: this.postId,
+        organism_url: this.organismUrl,
+        // user: {
+        //   name: '',
+        //   uid: '',
+        //   icon_url: ''
+        // },
+        title: this.postData.title,
+        place: this.postData.place,
+        recording_target: this.postData.target,
+        now_feeling: this.postData.feeling,
+        posted_at: this.postId
+      }
+
+      postsCollection.doc(this.postId).set(submitPostData)
+      .then(() => {
+        console.log(`success!! post ID: ${this.postId}`)
+        // this.$router.push('/')
+      })
+    }
+  }
+
+}
+</script>
+
+<style lang="scss" scoped>
+  input, textarea {
+    display: block;
+  }
+</style>

--- a/pages/recording.vue
+++ b/pages/recording.vue
@@ -105,7 +105,7 @@ export default {
       this.uploadOrganism(this.organismData).then(() => {
         console.log('アップ成功！！')
         // 新規投稿画面に遷移
-        // this.$router.push('/')
+        this.$router.push('/posts/new')
       })
     },
     async uploadOrganism(data) {

--- a/store/post.js
+++ b/store/post.js
@@ -2,8 +2,8 @@ import { db } from '~/plugins/firebase'
 
 export const state = () => ({
   postData: {
-    id: null,
-    organismUrl: null
+    id: '',
+    organismUrl: ''
   }
 })
 


### PR DESCRIPTION
refs #13 
- `posts/new.vue` の作成（デザインまだ）
  - [input, button]コンポーネント化していないので、CSSと共に後ほど
- 投稿するデータをまとめて、firestore に投稿
  - [user]まだデータがないのでコメントアウト