### PR TITLE
iOS Safari でレコーディングできるようにする

### DIFF
--- a/pages/recording.vue
+++ b/pages/recording.vue
@@ -63,11 +63,7 @@ export default {
     }
 
     navigator.mediaDevices.getUserMedia({
-      video: {
-        width: 375,
-        height: 375,
-        facingMode: { exact: "environment" }
-      },
+      video: { facingMode: { exact: "environment" }},
       audio: true
     })
     .then(stream => {
@@ -91,7 +87,7 @@ export default {
       }
 
       this.isActiveEffect = true
-      this.audioCtx = new(window.AudioContext || window.webkitAudioContext)
+      this.audioCtx = new AudioContext() || new webkitAudioContext()
       const biquadFilter = this.audioCtx.createBiquadFilter();
       biquadFilter.type = 'highshelf';     // ハイシェルフフィルター
       biquadFilter.frequency.value = 1000; // 周波数閾値

--- a/pages/recording.vue
+++ b/pages/recording.vue
@@ -4,6 +4,8 @@
       <div v-show="!blobUrl">
         <video
           :srcObject.prop="localStream"
+          width="375"
+          height="375"
           autoplay
           playsinline="true"
         />
@@ -47,6 +49,11 @@ export default {
     RecordButton,
     EffectBox
   },
+  head: {
+    script: [
+      { src: 'https://cdn.webrtc-experiment.com/MediaStreamRecorder.js' }
+    ]
+  },
   data:() => ({
     isRecorded: false,
     isActiveEffect: false,
@@ -63,7 +70,8 @@ export default {
     }
 
     navigator.mediaDevices.getUserMedia({
-      video: { facingMode: { exact: "environment" }},
+      // video: { facingMode: { exact: "environment" }},
+      video: true,
       audio: true
     })
     .then(stream => {

--- a/utils/record.js
+++ b/utils/record.js
@@ -1,7 +1,8 @@
 let mediaRecorder = null
 
 const startRec = stream => {
-  const options = { mimeType: 'video/webm;codecs=vp8'}
+  // const options = { mimeType: 'video/webm;codecs=vp8'}
+  const options = { mimeType: 'video/mp4; codecs=avc1.640028'}
   mediaRecorder = new MediaRecorder(stream, options)
   mediaRecorder.start()
 }

--- a/utils/record.js
+++ b/utils/record.js
@@ -1,8 +1,7 @@
 let mediaRecorder = null
 
 const startRec = stream => {
-  // const options = { mimeType: 'video/webm;codecs=vp8'}
-  const options = { mimeType: 'video/mp4; codecs=avc1.640028'}
+  const options = { mimeType: 'video/webm' }
   mediaRecorder = new MediaRecorder(stream, options)
   mediaRecorder.start()
 }

--- a/utils/record.js
+++ b/utils/record.js
@@ -1,19 +1,16 @@
 let mediaRecorder = null
 
 const startRec = stream => {
-  const options = { mimeType: 'video/webm' }
-  mediaRecorder = new MediaRecorder(stream, options)
+  mediaRecorder = new MediaStreamRecorder(stream)
+  mediaRecorder.mimeType = 'video/mp4'
   mediaRecorder.start()
 }
 
 const stopRec = () => {
   return new Promise(resolve => {
     mediaRecorder.stop()
-    mediaRecorder.ondataavailable = e => {
-      if (e.data && e.data.size > 0) {
-        const blob = new Blob([e.data], { type: "video/webm" })
-        resolve(blob)
-      }
+    mediaRecorder.ondataavailable = blob => {
+      resolve(blob)
     }
   })
 }


### PR DESCRIPTION
refs #35 

Mac OS
- Chrome　=> レコードできる、再生できる
- Safari　　=> レコードできない、再生できない

iOS Mobile
- Chrome　=> レコードできない、再生できない
- Safari　　=> レコードできない、再生できない

iOS Chrome では getUserMedia でカメラにアクセスすることができない。Safari は可能。
再生で`webm`を Safari は読み込まない。Chrome は可能。
mobile （iOS Safari）で再生できるようにするため、拡張子を`webm`から`mp4`に変えるプラグイン`MediaStreamRecorder`を使ってみた。
結果は上記の通りである。

Video データを Web で扱うのは OS 依存やブラウザ依存でうまくいかないことが多い。

#### 今後の開発
- 映像を取り扱っていたが、音声データをメインとし、カメラで画像をキャプチャする使用に変更する
- 拡張子は `.wav` でいく方針