### PR TITLE
投稿一覧ページでの再生処理

### DIFF
--- a/components/PlayButton.vue
+++ b/components/PlayButton.vue
@@ -17,6 +17,7 @@
 </template>
 
 <script>
+import { mapState, mapActions } from 'vuex'
 import IconPlay from '~/components/icons/IconPlay'
 import IconPause from '~/components/icons/IconPause'
 
@@ -34,25 +35,35 @@ export default {
   data:() => ({
     isPlaying: false
   }),
-  mounted() {
-    // const audio = new Audio(this.organismData)
-    const audio = this.$refs.organism
-    audio.onloadedmetadata = data => {
-      console.log(data)
-      console.log(audio.duration)
-      console.log(audio.ended)
+  computed: {
+    ...mapState({
+      playingOrganisms: store => store.organism.organisms.length
+    }),
+    isLimitPlaying() {
+      return this.playingOrganisms >= 4 ? true : false
     }
-    console.log(this.$refs.organism)
   },
   methods: {
+    ...mapActions('organism', ['setOrganism', 'resetOrganism']),
     playOrganism() {
       if (this.isPlaying) {
-        this.isPlaying = false
-        this.$refs.organism.pause()
+        this.pauseOrganism()
         return
       }
+
+      if (this.isLimitPlaying) {
+        alert('Mixing organisms is already maximum count!!')
+        return
+      }
+
       this.isPlaying = true
+      this.setOrganism(this.organismData)
       this.$refs.organism.play()
+    },
+    pauseOrganism() {
+      this.isPlaying = false
+      this.resetOrganism(this.organismData)
+      this.$refs.organism.pause()
     }
   }
 }

--- a/components/PlayButton.vue
+++ b/components/PlayButton.vue
@@ -1,8 +1,12 @@
 <template>
   <div
     class="play_button__container"
-    @click="handleClick"
+    @click="playOrganism"
   >
+    <audio
+      ref="organism"
+      :src="organismData"
+    />
     <icon-play
       v-if="!isPlaying"
     />
@@ -22,14 +26,33 @@ export default {
     IconPause
   },
   props: {
-    isPlaying: {
-      type: Boolean,
-      default: false
+    organismData: {
+      type: String,
+      default: ''
     }
   },
+  data:() => ({
+    isPlaying: false
+  }),
+  mounted() {
+    // const audio = new Audio(this.organismData)
+    const audio = this.$refs.organism
+    audio.onloadedmetadata = data => {
+      console.log(data)
+      console.log(audio.duration)
+      console.log(audio.ended)
+    }
+    console.log(this.$refs.organism)
+  },
   methods: {
-    handleClick() {
-      this.$emit('click')
+    playOrganism() {
+      if (this.isPlaying) {
+        this.isPlaying = false
+        this.$refs.organism.pause()
+        return
+      }
+      this.isPlaying = true
+      this.$refs.organism.play()
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,17 +10,11 @@
         <div
           class="post_organism__thumbnail"
           :style="getThumbnailImage(post.thumbnail_url)"
-        >
-          <audio
-            ref="organism"
-            :src="post.organism_url"
-          />
-        </div>
+        />
         <div class="post_organism__feature">
           <div class="post_organism__feature__play_button">
             <play-button
-              :is-playing="isPlaying"
-              @click="playOrganism"
+              :organism-data="post.organism_url"
             />
           </div>
           <div class="post_organism__feature__info">
@@ -50,9 +44,6 @@ export default {
   components: {
     PlayButton
   },
-  data:() => ({
-    isPlaying: false
-  }),
   computed: {
     ...mapState({
       feedPosts: store => store.post.feedPosts
@@ -69,16 +60,6 @@ export default {
     getThumbnailImage(url) {
       return `background-image: url(${url})`
     },
-    playOrganism() {
-      if (this.isPlaying) {
-        this.isPlaying = false
-        this.$refs.organism[0].pause()
-        return
-      }
-      this.isPlaying = true
-      console.log(this.$refs.organism)
-      this.$refs.organism[0].play()
-    }
   }
 
 }

--- a/store/organism.js
+++ b/store/organism.js
@@ -1,0 +1,21 @@
+export const state = () => ({
+  organisms: []
+})
+
+export const mutations = {
+  SET_ORGANISM(state, data) {
+    state.organisms.push(data)
+  },
+  RESET_ORGANISM(state, data) {
+    state.organisms = state.organisms.filter(_data => _data !== data)  
+  }
+}
+
+export const actions = {
+  setOrganism({ commit }, data) {
+    commit('SET_ORGANISM', data)
+  },
+  resetOrganism({ commit }, data) {
+    commit('RESET_ORGANISM', data)
+  }
+}


### PR DESCRIPTION
refs #47 #17 
#### 再生処理
- コンポーネントにデータのURLを渡して、単独再生できるようにした

#### 同時再生処理
- store に `organism.js` を作成し、今再生しているデータを配列で管理
- 再生するたびに、配列のレングスを取得し最大同時再生数（４）であれば再生されない仕様
- 停止時は音声を一時停止するとともに、`organism.js` で管理している配列からもデータを削除