### PR TITLE
録音処理の修正

### DIFF
--- a/components/EffectBox.vue
+++ b/components/EffectBox.vue
@@ -32,8 +32,8 @@ export default {
 <style lang="scss" scoped>
 .effect_box__container {
   width: 10rem;
-  height: 5rem;
-  line-height: 5rem;
+  height: 6rem;
+  line-height: 6rem;
   text-align: center;
   border: .2rem solid $color-white;
   border-radius: .8rem;

--- a/pages/recording.vue
+++ b/pages/recording.vue
@@ -10,7 +10,17 @@
     <div class="effect_box__container">
       <effect-box
         :is-active="isActiveEffect"
-        effect-label="Destortion"
+        effect-label="Fuzz"
+        @click="effectProcessing"
+      />
+      <effect-box
+        :is-active="isActiveEffect"
+        effect-label="Reverb"
+        @click="effectProcessing"
+      />
+      <effect-box
+        :is-active="isActiveEffect"
+        effect-label="Delay"
         @click="effectProcessing"
       />
     </div>
@@ -81,6 +91,10 @@ export default {
         this.audioCtx.close()
         this.isActiveEffect = false
         return
+      }
+
+      if (this.audioCtx.state === 'closed') {
+        this.audioCtx = new AudioContext()
       }
 
       this.isActiveEffect = true

--- a/pages/recording.vue
+++ b/pages/recording.vue
@@ -107,6 +107,7 @@ export default {
     },
     async stopRecording() {
       this.organismData = await stopRec()
+      this.audioCtx.close()
       this.blobUrl = window.URL.createObjectURL(this.organismData)
       this.uploadOrganism(this.organismData).then(() => {
         console.log('アップ成功！！')

--- a/utils/record.js
+++ b/utils/record.js
@@ -1,7 +1,7 @@
 import exportWAV from '~/utils/export_wav.js'
 
-const audioData = []
 const bufferSize = 2048
+let audioData
 let sampleRate
 
 const onAudioProcess = e => {
@@ -15,6 +15,7 @@ const onAudioProcess = e => {
 
 
 const startRec = (stream, ctx) => {
+  audioData = [] // initialize audioData
   const scriptProcessor = ctx.createScriptProcessor(bufferSize, 1, 1)
   const mediaStreamSource = ctx.createMediaStreamSource(stream)
   sampleRate = ctx.sampleRate


### PR DESCRIPTION
refs #45 

#### 録音処理をして再度録音をすると、二重で録音してしまうバグ
- 録音開始時にデータを格納する配列を初期化して回避

#### エフェクトがかからないバグ
- エフェクト解除時、`audioContext.close()` をしている
- エフェクト開始時、`audioContext` の state が `closed` だったら、初期化