### PR TITLE
投稿のテキストのスタイルを修正

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -131,8 +131,16 @@ export default {
     padding: .5rem;
     color: $color-white;
 
+    & * {
+      width: 11rem;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
     & > p {
       font-size: 1.2rem;
+
     }
   }
 }


### PR DESCRIPTION
refs #33 
- 投稿の文字情報が最大幅以上の文字数になったら、` ... ` と表示されるようにした